### PR TITLE
Delete outdated build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-use vergen::{ConstantsFlags, generate_cargo_keys};
-
-const ERROR_MSG: &str = "Failed to generate metadata files";
-
-fn main() {
-	generate_cargo_keys(ConstantsFlags::SHA_SHORT).expect(ERROR_MSG);
-
-	build_script_utils::rerun_if_git_head_changed();
-}


### PR DESCRIPTION
This PR deletes a single `build.rs` file from the root. That file was used before the node template was restructured into `node`, `runtime`, and `pallets` directories. The new home for this file is `node/build.rs` so this one can be safely deleted.