### PR TITLE
alpha.6 to github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
+checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
 name = "arrayref"
@@ -132,8 +132,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
 dependencies = [
  "cc",
  "libc",
@@ -264,7 +264,7 @@ dependencies = [
  "log",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "regex",
  "rustc-hash",
  "shlex",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
+checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bstr"
@@ -436,9 +436,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 dependencies = [
  "jobserver",
 ]
@@ -681,8 +681,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -769,27 +769,27 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7abcddbdd5db30aeed4deb586adc4824e6c247e2f7238d1187f752893f096b"
+checksum = "befe713756981dbbda28e23f5c65c85de512915db695284342cc2ee36b7a184f"
 dependencies = [
  "crunchy",
  "fixed-hash",
  "impl-rlp",
- "impl-serde 0.3.0",
+ "impl-serde 0.3.1",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964c23cdee0ca07d5be2a628b46d5c11a2134ce554a8c16d8dbc2db647e4fd4d"
+checksum = "8616dc6a7bc7d81ab8a6425635299ee3582975d4ddeb9312b8b0b8ea54dfecf8"
 dependencies = [
  "ethbloom",
  "fixed-hash",
  "impl-rlp",
- "impl-serde 0.3.0",
+ "impl-serde 0.3.1",
  "primitive-types",
  "uint",
 ]
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -815,13 +815,13 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "synstructure",
 ]
 
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32529fc42e86ec06e5047092082aab9ad459b070c5d2a76b14f4f5ce70bf2e84"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
@@ -894,8 +894,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4492b78f0aec7271d261e0f1025297012c7853c263e036d15790f9ca99e72"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -903,8 +902,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2fc91a6a976ce87b105722d8d9cdc44d4cb03ad24493d34cbfb64bbaacb7ee"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -921,8 +919,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2941cd59682f596645d54b0e84c02e98f9be53a346841c720ead60cdbadb3463"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -935,8 +932,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5eaf1cd17755f099188d76995520a3179fedf0cb631264b8759dea0cd2e981"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -947,8 +943,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4058dce75ae1d45b469a8cbbe0c9dc3083e5546936b60e4647e73584e0f7ba7"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -972,44 +967,40 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefa7eb42406f732f87f8331aaaa787a65abe0f5f681a59fac1737ba4e81d89e"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0fce760be3b164dd44ba5826f6a504c485020f6813604d4c73b42b50797d71"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c453b69522957f835e3679e8a98a90a3859481423bf5a2c570397c416339dcf5"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-system"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c97e7168ca4cd7b2358ca30da4c5aba4a2b9b5eef45df67ca85b3dd59069a5"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1160,8 +1151,8 @@ checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1332,7 +1323,7 @@ dependencies = [
  "indexmap",
  "log",
  "slab",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "tokio-util",
 ]
 
@@ -1372,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -1516,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
+checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
@@ -1533,7 +1524,7 @@ dependencies = [
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "tower-service",
  "want 0.3.0",
 ]
@@ -1547,11 +1538,11 @@ dependencies = [
  "bytes 0.5.4",
  "ct-logs",
  "futures-util",
- "hyper 0.13.4",
+ "hyper 0.13.5",
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "tokio-rustls",
  "webpki",
 ]
@@ -1607,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
 dependencies = [
  "serde",
 ]
@@ -1621,8 +1612,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1697,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1750,8 +1741,8 @@ checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1843,7 +1834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -1873,7 +1864,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -1924,9 +1915,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5aedb713f76577818529be8283e35ec5e8b3ecdccfe0231ba4d860687438ab"
+checksum = "32ea742c86405b659c358223a8f0f9f5a9eb27bb6083894c6340959b05269662"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -1949,7 +1940,7 @@ dependencies = [
  "parity-multiaddr 0.8.0",
  "parking_lot 0.10.2",
  "pin-project",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "wasm-timer",
 ]
 
@@ -1980,7 +1971,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -1993,8 +1984,8 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2020,7 +2011,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "wasm-timer",
 ]
 
@@ -2044,7 +2035,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "uint",
  "unsigned-varint",
  "void",
@@ -2068,7 +2059,7 @@ dependencies = [
  "log",
  "net2",
  "rand 0.7.3",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "void",
  "wasm-timer",
 ]
@@ -2127,15 +2118,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622605817885e67b5572189c2507e514b786beb69ed85a120dbb245a7f15383d"
+checksum = "44ab289ae44cc691da0a6fe96aefa43f26c86c6c7813998e203f6d80f1860f18"
 dependencies = [
  "futures 0.3.4",
  "libp2p-core",
  "log",
  "rand 0.7.3",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "void",
  "wasm-timer",
 ]
@@ -2205,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.6.4"
+version = "6.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3b727e2dd20ec2fb7ed93f23d9fd5328a0871185485ebdaff007b47d3e27e4"
+checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
 dependencies = [
  "bindgen",
  "cc",
@@ -2373,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -2404,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
@@ -2456,7 +2447,7 @@ dependencies = [
  "futures 0.3.4",
  "log",
  "pin-project",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "unsigned-varint",
 ]
 
@@ -2488,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2679,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -2730,8 +2721,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9757d44df3ff0372ea313703736e69ba361b158a58b7c9677b54be11a777da81"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2752,8 +2742,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef08001886d3747220630337f7afbb8f1d7cbfacaa3a8a13317e1cb3e8e366"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2768,8 +2757,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d89d58fe723cc05bdfc5f237a51e275bf58dcafb493ad68211c27ecd8f1afd"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2785,8 +2773,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed9f0fe5149552a1f1f26f4ed8999d692e0e209c54314c4f28a9bd8a1a1161d"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2804,8 +2791,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1139a9bf489b947a677574ee8ade27c7b710ce25a07f1630b80c20af8f682f91"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2818,8 +2804,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fdeb41738a79d3247b2a7fd9ce8ae5a7d9e92ca2de198e006f891240c8dcacc"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2837,8 +2822,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b15e01796c9d2791cbd9ae2d7c9b59c8eccc3682afbb1189f6ebe7b07f4d71"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2864,8 +2848,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9de9af5f5ed3377a6108eed436791bfe18bc3e4e2e416854d0074d31b1be00"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2882,8 +2865,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54768f5959e0bef53218b91f289d6807c0786d93fb90a3c7e39ab7ff9f018f23"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2896,8 +2878,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7323ef565470b51bb79fc65d3c3a1bff0ecb317485acc66a64406309c25f1b77"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2979,8 +2960,8 @@ checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3003,7 +2984,7 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "winapi 0.3.8",
 ]
 
@@ -3014,7 +2995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2",
- "syn 1.0.17",
+ "syn 1.0.18",
  "synstructure",
 ]
 
@@ -3042,7 +3023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.7.1",
+ "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -3062,23 +3043,23 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "paste"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4fb1930692d1b6a9cfabdde3d06ea0a7d186518e2f4d67660d8970e2fa647a"
+checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -3086,14 +3067,14 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
+checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3136,22 +3117,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "36e3dcd42688c05a66f841d22c5d8390d9a5d4c9aaf57b9285eae4900a080063"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "f4d7346ac577ff1296e06a418e7618e22655bae834d4970cb6e39d6da8119969"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3162,9 +3143,9 @@ checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3186,14 +3167,14 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "primitive-types"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
+checksum = "c55c21c64d0eaa4d7ed885d959ef2d62d9e488c27c0e02d9aa5ce6c877b7d5f8"
 dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.3.0",
+ "impl-serde 0.3.1",
  "uint",
 ]
 
@@ -3214,8 +3195,8 @@ checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "version_check",
 ]
 
@@ -3226,8 +3207,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "syn-mid",
  "version_check",
 ]
@@ -3246,9 +3227,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -3319,8 +3300,8 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3364,9 +3345,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -3607,9 +3588,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3634,13 +3615,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.12"
+version = "0.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
+checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
 dependencies = [
  "cc",
- "lazy_static",
  "libc",
+ "once_cell",
  "spin",
  "untrusted",
  "web-sys",
@@ -3747,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "safe-mix"
@@ -3763,8 +3744,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eeea19615c22c30accd79ca751b7db8642a3a88572432624a88c6754b6c7d33"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -3786,8 +3766,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7b45adef0526ef295a9b7da4af933322df7119385a78c2e96c99b5d54fcc35"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -3803,8 +3782,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d37957c58cb0cf1fa9fe1187447d16e4708a7a0541ee2c1226b2536f4241742"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -3820,20 +3798,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2703f02f31f53601ed0408df76939a2e1911ff64a146e7b15ed1be56193e91ba"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46513d8e34913e19ffb8663ff211528f5590712c3c4e69bfa41ca748120a2001"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -3869,14 +3845,13 @@ dependencies = [
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
- "tokio 0.2.18",
+ "tokio 0.2.20",
 ]
 
 [[package]]
 name = "sc-client"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9908c438f8e60d07c97a7f1d4ea8c6d31a498f283373c533f2006c032b9a4971"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "fnv",
@@ -3911,8 +3886,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a2271c80a792efffc4abfe9be8b87c9747721cfa4426f3b707283a431bbacd"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "fnv",
@@ -3946,8 +3920,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1ae5b4c8333cb751cd9bbc7ecf0eb1c55d4865fca6651066844febcec71618"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -3974,8 +3947,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a476e0650893a4e8c086c14f1ea5fde4a3de9f654a75c706f2c362406ee4d588"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -4006,8 +3978,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec4ede5a5b469f5cc1ac9fd304c7683f1e57638e5d9f8f23df6a98758b9cc24"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -4028,8 +3999,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f238a411de5e1cfe3b104f287aad0a48e4a39d9157171b7761d91d6d4a76610a"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -4055,8 +4025,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549d94ce1316c168a72c26abf0bf3390ae76b1645030e2aac9ecf0542b04fa85"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "log",
@@ -4073,8 +4042,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7efc6978b59884e1593ec172fe5b1a909c980b0e495897c904da50616c3a7a"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4089,8 +4057,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bcf9e6787b6b421c2152e3d876105dec0c4cfa9fdac6bca54bec404d79a8593"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "assert_matches",
  "finality-grandpa",
@@ -4126,8 +4093,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03ec9890c64668809ac230921c504f18dc79bec75addf02da197b437d740dda"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -4144,8 +4110,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd2f3cb18368d58af4946e277b9e4bea605feb65872116130c1dd0905f341e3"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "hex",
@@ -4160,8 +4125,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda92d4930bd77f3d215504ce16a3715585d8fc7c3d7be3c6f6891ee841f5686"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "bitflags",
  "bytes 0.5.4",
@@ -4213,8 +4177,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f954d0ce6279fe48df2d3d20d3e5589964d501509f85b323cb0fde37b1b90"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -4230,14 +4193,13 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3544cf74f21323eac40c965a3ccda06d828875127e7966c0a05db9686460bf34"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "hyper 0.13.4",
+ "hyper 0.13.5",
  "hyper-rustls",
  "log",
  "num_cpus",
@@ -4258,8 +4220,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b85bec68c3c1b4495b6eabdf14d1c4140a6d569b61af9c4f721f23eae42ed7"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -4272,8 +4233,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f8136a2d703b2f4aeb970707ec83d55ae584c3c0af7aa10b3bd93b227a6fd0"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -4306,8 +4266,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c681fed8a6aab250f1fbb0848dee73c199bbcf94dc03f27edb57d2c50f0cff3"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -4331,8 +4290,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d090ab799eaf3e41f36cdd9c79c2f5d1b0eeefc5f3422bc273084badd7ff62"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -4347,8 +4305,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6863666dc415a261bb21dfe599403fb977720feb5bc6ebacf078f5f78c165b"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "exit-future",
@@ -4399,8 +4356,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31877c85414ed8e19a480940d7ae340832e7616208072cb43982fdcdd176021"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4414,8 +4370,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdaddc5a9aaeabbe68599ae2bfa4f247fa1617e8a119f4665884757052697035"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -4437,8 +4392,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a0c0eecadf7c89b09e4e7290b301ffd8c3b30af4d1aa47d147f32f9d9e0b33"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "erased-serde",
  "log",
@@ -4453,8 +4407,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7f1ad6be774288fd73818271d3041442956a149a461de22f97f12210fdc776"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -4474,8 +4427,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9c7db165344a2d45dc1b7d0a52e1028198b25adba8406e05055f4c5e5626b8"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -4542,9 +4494,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4555,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4600,15 +4552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -4730,8 +4682,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -4745,9 +4697,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "snow"
@@ -4782,7 +4734,7 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "sha1",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "static_assertions",
  "thiserror",
 ]
@@ -4790,8 +4742,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532c396c2d6727d9b0d3eee3edbcaf939e78a6ce944fa34c2b98d6a02a2485e"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "log",
@@ -4803,8 +4754,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a4df52a0c56d742fc75f4da486627c1b050be2ac87cc042c2c0246756f22d2"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -4819,21 +4769,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff834a833fd8beda20cd588341cdae52336f02f60aa6f0a34d9fd4d91975b369"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5dec618ed8ea85fd767358185a412440c02a0adce569c2aa92ee355550d678"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -4845,8 +4793,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b413966b541aadf8725dddc29daeefa950f45b17208f33302890484c56009bd3"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -4860,8 +4807,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70049c389c66c4c9207149e2579ce6d752788dee8c596fbda76059f2ddde968f"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4873,8 +4819,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db268602314a0f3a028ef6073185a6a5e0b8e7703da306e72e8a1fcbd2a0c05"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "log",
@@ -4890,8 +4835,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d73d557c214577b64a396e54f337403e251339a6599387747ae3570a19bb27"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "serde",
  "serde_json",
@@ -4900,8 +4844,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4eec34198eb14fc2ef129df522e28df5ce6aeea886369ef2eafaaec6bc4fc7"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -4924,8 +4867,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5ffbc4aca29fe7a0f0c419445e34758210dba6418eeb101d60c1e15b27797a"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4939,8 +4881,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6108fbecddd95ce8151f09e8ecb0941b3eddcfeefb4c996f27a8a8b4827abd"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4956,8 +4897,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba3eef8ab960eb88307f1c4eda1c36dfd95dc933bd6a277d2e26a503a6e5a71"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -4969,8 +4909,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0589a2e394a3dcd5dfd258c5f5bf22e6d0f28ffbd5e6d3a09ad702a6dc1c0152"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -4980,7 +4919,7 @@ dependencies = [
  "hash-db",
  "hash256-std-hasher",
  "hex",
- "impl-serde 0.3.0",
+ "impl-serde 0.3.1",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -5010,19 +4949,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df968a922a9d3b3f65d37e91e30904876efce88d017d4448c4babc990a738134"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06b8ac80a03205205426ae9ef3200133a8ffab4f4f0eeecd3b858034f9e5b02"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "environmental",
  "sp-std",
@@ -5032,8 +4969,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7107d11f07fb400a0d71838225865e2bf27f79241751ef9ff1501980dd63b3"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -5046,8 +4982,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f718fb1e75fd137b01b539a200cf5e3cd1e0f1d21dc55a03341d7e25c81624"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -5057,8 +4992,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f699ab5cac6c9e80197774f06a4aa38211cb8acdb8660e328775efa2599e1"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5070,8 +5004,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20758b1831f75d58c20ca735d34b96dc792ef8264bf4d4a8c476964d90a6aea7"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "hash-db",
  "libsecp256k1",
@@ -5089,8 +5022,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f71e65eb13d8a4d320d3785558ac8fc12f8b2bdbfc5268c0e8a5a143d68686e"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -5101,8 +5033,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc02ea51f7abe7e8999658a8a41693426f14e66cff6cc5af989888289ad0fc"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -5111,8 +5042,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef909e5ea664bce0bca723baf352c75125e4ed017843240e91d718df4720e1e4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "backtrace",
  "log",
@@ -5121,8 +5051,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d29a58ef51317f96eec408b40c604ccfe8c7c3b9ecc2636e2a9c84a79fae53a"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "serde",
  "sp-core",
@@ -5131,8 +5060,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1f98caf8bb20c7d69ba3097f3283ebc615f4a33e79ae0ca5934364be5776ac"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -5153,8 +5081,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289491386162a8d867d219f4f4dd3a7c11181c8ee9957e41b8747b555a9f4433"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -5168,21 +5095,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609529717f6c9cdd5bb6329c4ca9ddb1d36f698bd1f5dd2bdf0e94c064d7cc5b"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b306e15eb54af25aef9d752c22778da3fa115945e47bf047545be2847cf814"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "serde",
  "serde_json",
@@ -5191,8 +5116,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fca3ff8ddd14c5928536483d4b393bb795d55dcb5b576b1dceb3f5829216c76"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -5203,8 +5127,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d7105e78848b8a8f6af3539a0cf7d9627b78a8776f61f43769da6406937ea9"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -5214,8 +5137,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5de28eb08ce52f45ed32257b324766183dfe4d74a29242b934365ff80911ca"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "hash-db",
  "log",
@@ -5234,14 +5156,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca806523d5df8082c89da042e31292f0c8f6e6ad9c3cfc312edfffde6a08490"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cb515df8b37fbdbb6769d2e992748b6134d592ec3b795b8e672621d754f94b"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "impl-serde 0.2.3",
  "serde",
@@ -5252,8 +5172,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd289fc7dbbae54cfe4db93a204df6371d6f3b5b8d5819fa7287e7d44a83eb86"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5267,8 +5186,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62c89a439db3f248980da189811e45666b758bc3cb8a9eb587d73d2e91b3403"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -5283,8 +5201,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4194817027eb92525e9279ec651160d709340d74b707f7648654c8eb2a626be3"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -5298,8 +5215,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3cd7ac8f6d105dd1d9483f7d2d20e0e77cecdfe0a7fe6d0bd0616cebb80ce3"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -5310,8 +5226,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319c37fa4aa91ee9ee9c20a3fab0d5b6b1bbe1dea997319c303f28a62f49765d"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -5323,8 +5238,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7584168f2785f6676727545a31a3cd97159d7023d968540b4881a98d73991900"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5376,9 +5290,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
+checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
  "clap",
  "lazy_static",
@@ -5387,15 +5301,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
+checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5415,8 +5329,8 @@ checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5434,8 +5348,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0abd8ab46d560d0d5cffd8d016c6b75eb5df91885b1b226b819ab600f02237c"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "platforms",
 ]
@@ -5443,23 +5356,21 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cad984ef1fec55fe46843630566f98cde0ad3de07efbbf8a4f857b36fedf30"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.6#67f354f57e738fa575775f7fa0fb903e8972182b"
 dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.4",
+ "hyper 0.13.5",
  "log",
  "prometheus",
- "tokio 0.2.18",
+ "tokio 0.2.20",
 ]
 
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
+source = "git+https://github.com/paritytech/substrate.git#3f27afa8640138c9942ceb09016da47ab7a5afaa"
 
 [[package]]
 name = "subtle"
@@ -5486,12 +5397,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "unicode-xid 0.2.0",
 ]
 
@@ -5502,8 +5413,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5522,8 +5433,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "unicode-xid 0.2.0",
 ]
 
@@ -5582,22 +5493,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5611,21 +5522,20 @@ dependencies = [
 
 [[package]]
 name = "threadpool"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
+checksum = "e8dae184447c15d5a6916d973c642aec485105a13cd238192a6927ae3e077d66"
 dependencies = [
  "num_cpus",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
@@ -5680,9 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -5802,7 +5712,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "webpki",
 ]
 
@@ -5914,7 +5824,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.18",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -5949,8 +5859,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5972,7 +5882,7 @@ dependencies = [
  "hashbrown",
  "log",
  "rustc-hex",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -6007,9 +5917,9 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
+checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -6041,7 +5951,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -6082,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -6116,9 +6026,9 @@ checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -6161,9 +6071,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6171,24 +6081,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6198,32 +6108,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "wasm-timer"
@@ -6266,9 +6176,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6341,9 +6251,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi 0.3.8",
 ]
@@ -6429,7 +6339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
- "syn 1.0.17",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "synstructure",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,57 +22,86 @@ path = '../runtime'
 version = '2.0.0-alpha.6'
 
 [dependencies.sc-basic-authorship]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-cli]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-client]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-client-api]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-consensus-aura]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-executor]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-finality-grandpa]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-network]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-service]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sc-transaction-pool]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-consensus]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-consensus-aura]
+git = 'https://github.com/paritytech/substrate.git'
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-core]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-finality-grandpa]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-inherents]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-runtime]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-transaction-pool]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
+
 [build-dependencies.substrate-build-script-utils]
-version = '2.0.0-alpha.6'
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-alpha.6'
 
 [[bin]]
 name = 'node-template'

--- a/pallets/template/Cargo.toml
+++ b/pallets/template/Cargo.toml
@@ -18,23 +18,29 @@ package = 'parity-scale-codec'
 version = '1.3.0'
 
 [dependencies.frame-support]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.frame-system]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
+
 [dev-dependencies.sp-core]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dev-dependencies.sp-io]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dev-dependencies.sp-runtime]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [features]
 default = ['std']

--- a/pallets/template/Cargo.toml
+++ b/pallets/template/Cargo.toml
@@ -20,27 +20,27 @@ version = '1.3.0'
 [dependencies.frame-support]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.frame-system]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dev-dependencies.sp-core]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dev-dependencies.sp-io]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dev-dependencies.sp-runtime]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [features]
 default = ['std']

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,41 +2,41 @@
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-aura'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.balances]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-balances'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.codec]
 default-features = false
 features = ['derive']
 package = 'parity-scale-codec'
-version ='1.3.0'
+version = '1.3.0'
 
 [dependencies.frame-executive]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.frame-support]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.grandpa]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-grandpa'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.randomness-collective-flip]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-randomness-collective-flip'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.serde]
 features = ['derive']
@@ -46,12 +46,12 @@ version = '1.0.101'
 [dependencies.sp-api]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-block-builder]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-consensus-aura]
 git = 'https://github.com/paritytech/substrate.git'
@@ -62,59 +62,59 @@ tag = 'v2.0.0-alpha.6'
 [dependencies.sp-core]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-inherents]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-io]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-offchain]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-runtime]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-session]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-std]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-transaction-pool]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-version]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sudo]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-sudo'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.system]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'frame-system'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.template]
 default-features = false
@@ -126,13 +126,13 @@ version = '2.0.0-alpha.6'
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-timestamp'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.transaction-payment]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-transaction-payment'
-tag ='v2.0.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [build-dependencies.wasm-builder-runner]
 git = 'https://github.com/paritytech/substrate.git'

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,36 +1,42 @@
 [dependencies.aura]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-aura'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.balances]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-balances'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.codec]
 default-features = false
 features = ['derive']
 package = 'parity-scale-codec'
-version = '1.3.0'
+version ='1.3.0'
 
 [dependencies.frame-executive]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.frame-support]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.grandpa]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-grandpa'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.randomness-collective-flip]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-randomness-collective-flip'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.serde]
 features = ['derive']
@@ -38,62 +44,77 @@ optional = true
 version = '1.0.101'
 
 [dependencies.sp-api]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-block-builder]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-consensus-aura]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 version = '0.8.0-alpha.6'
+tag = 'v2.0.0-alpha.6'
 
 [dependencies.sp-core]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-inherents]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-io]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-offchain]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-runtime]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-session]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-std]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-transaction-pool]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sp-version]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.sudo]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-sudo'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.system]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'frame-system'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.template]
 default-features = false
@@ -102,16 +123,19 @@ path = '../pallets/template'
 version = '2.0.0-alpha.6'
 
 [dependencies.timestamp]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-timestamp'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [dependencies.transaction-payment]
+git = 'https://github.com/paritytech/substrate.git'
 default-features = false
 package = 'pallet-transaction-payment'
-version = '2.0.0-alpha.6'
+tag ='v2.0.0-alpha.6'
 
 [build-dependencies.wasm-builder-runner]
+git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-wasm-builder-runner'
 version = '1.0.5'
 


### PR DESCRIPTION
If merged, it requires to push the tag to this commit.

Fixes incorrect alpha.7 dependencies.