### PR TITLE
Use docker to setup a local dev chain 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 **/*.rs.bk
 
 .DS_Store
+
+# The cache for docker container dependency
+.cargo

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # The cache for docker container dependency
 .cargo
+
+# The cache for chain data in container
+.local

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ If you just want to run the compiled binary,
 ./scripts/docker_run.sh ./target/release/node-template --dev --ws-external
 ```
 
+Other commands are similar. Let's try purge the local dev chain here:
+
+```bash
+./scripts/docker_run.sh ./target/release/node-template purge-chain --dev
+```
+
 You can also check whether the code is able to compile or not,
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Additional CLI usage options are available and may be shown by running `cargo ru
 
 ### Run in Docker
 
-Install Docker first, then run following command to start a single node development chain.
+Install [Docker](https://docs.docker.com/get-docker/) first, then run following command to start a single node development chain.
 
 ```bash
 ./scripts/docker_run.sh

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Additional CLI usage options are available and may be shown by running `cargo ru
 
 ### Run in Docker
 
-Install [Docker](https://docs.docker.com/get-docker/) first, then run following command to start a single node development chain.
+Install [Docker](https://docs.docker.com/get-docker/) first, then run the following command to start a single node development chain.
 
 ```bash
 ./scripts/docker_run.sh

--- a/README.md
+++ b/README.md
@@ -82,10 +82,22 @@ Additional CLI usage options are available and may be shown by running `cargo ru
 
 ### Run in Docker
 
-Install [Docker](https://docs.docker.com/get-docker/) first, then run the following command to start a single node development chain.
+Install [Docker](https://docs.docker.com/get-docker/) first, then run the following command to start a single node development chain. This command will firstly comipile your code, then start a local dev netork.
 
 ```bash
 ./scripts/docker_run.sh
+```
+
+If you just want to run the compiled binary,
+
+```bash
+./scripts/docker_run.sh ./target/release/node-template --dev --ws-external
+```
+
+You can also check whether the code is able to compile or not,
+
+```bash
+./scripts/docker_run.sh cargo check
 ```
 
 ## Advanced: Generate Your Own Substrate Node Template

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ cargo run -- \
 
 Additional CLI usage options are available and may be shown by running `cargo run -- --help`.
 
+### Run in Docker
+
+Install Docker first, then run following command to start a single node development chain.
+
+```bash
+./scripts/docker_run.sh
+```
+
 ## Advanced: Generate Your Own Substrate Node Template
 
 A substrate node template is always based on a certain version of Substrate. You can inspect it by

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
       - type: bind
         source: ./cargo
         target: /root/.cargo
-    command: cargo run --release -- --dev --ws-external
+    command: bash -c "cargo build --release && ./target/release/node-template --dev --ws-external"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.2"
+
+services:
+  dev:
+    container_name: node-template
+    image: parity/rust-builder:latest
+    working_dir: /var/www/node-template
+    ports:
+      - "9944:9944"
+    environment:
+      - CARGO_HOME=/var/www/node-template/.cargo
+    volumes:
+      - .:/var/www/node-template
+      - type: bind
+        source: ./cargo
+        target: /root/.cargo
+    command: cargo run --release -- --dev --ws-external

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
     volumes:
       - .:/var/www/node-template
       - type: bind
-        source: ./cargo
-        target: /root/.cargo
+        source: ./.local
+        target: /root/.local
     command: bash -c "cargo build --release && ./target/release/node-template --dev --ws-external"

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "*** Start Substrate node template ***"
+
+cd $(dirname ${BASH_SOURCE[0]})/..
+
+docker-compose down --remove-orphans
+docker-compose run --rm --service-ports dev $@


### PR DESCRIPTION
I recently need to help solve the variance of platforms when developing on Substrate.
Docker is still the first choice when dealing with this situation. 

It would be good to know how are we going to support different platforms in the long term.

This change works in my MacOS, but haven't tested it in other platforms.