### PR TITLE
Remove rust-toolchain file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Once the development environment is set up, build the node template. This comman
 [native](https://substrate.dev/docs/en/knowledgebase/advanced/executor#native-execution) code:
 
 ```bash
-cargo build --release
+WASM_BUILD_TOOLCHAIN=nightly-2020-10-05 cargo build --release
 ```
 
 ## Run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "9944:9944"
     environment:
       - CARGO_HOME=/var/www/node-template/.cargo
+      - WASM_BUILD_TOOLCHAIN=nightly-2020-10-05
     volumes:
       - .:/var/www/node-template
       - type: bind

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,0 @@
-stable-x86_64-unknown-linux-gnu
-nightly-2020-10-05


### PR DESCRIPTION
Architecture specific toolchains are [not allowed](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) in this file. We can assume that stable is the default toolchain and should not dictate with which toolchain the user builds the client. Also this breaks under macOS.

We are only interested with which toolchain the runtime is build. For this we should set the `WASM_BUILD_TOOLCHAIN` variable.