### PR TITLE
Bump wasm-builder-runner

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies]
-wasm-builder-runner = { package = 'substrate-wasm-builder-runner', version = '1.0.5' }
+wasm-builder-runner = { package = 'substrate-wasm-builder-runner', version = '2.0.0' }
 
 # alias "parity-scale-code" to "codec"
 [dependencies.codec]


### PR DESCRIPTION
1.0 wasm-builder-runner is not compatible with 2.0 wasm-builder https://github.com/paritytech/substrate/pull/7283#issuecomment-705824314

and we are using https://github.com/substrate-developer-hub/substrate-node-template/blob/5785c8d71da7882abf04748bf1dc61974638a922/runtime/build.rs#L6