### PR TITLE
Patch Multiaddress Into Substrate Node Template

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -94,9 +94,9 @@ pub mod opaque {
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node-template"),
 	impl_name: create_runtime_str!("node-template"),
-	authoring_version: 100,
+	authoring_version: 1,
 	spec_version: 100,
-	impl_version: 100,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 100,
 };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,7 +13,7 @@ use sp_runtime::{
 	transaction_validity::{TransactionValidity, TransactionSource},
 };
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, IdentityLookup, Verify, IdentifyAccount, NumberFor, Saturating,
+	BlakeTwo256, Block as BlockT, Verify, IdentifyAccount, NumberFor, Saturating,
 };
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -141,7 +141,7 @@ impl frame_system::Trait for Runtime {
 	/// The aggregated dispatch type that is available for extrinsics.
 	type Call = Call;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-	type Lookup = IdentityLookup<AccountId>;
+	type Lookup = multiaddress::AccountIdLookup<AccountId, ()>;
 	/// The index type for storing how many extrinsics an account has signed.
 	type Index = Index;
 	/// The index type for blocks.
@@ -287,7 +287,8 @@ construct_runtime!(
 );
 
 /// The address format for describing accounts.
-pub type Address = AccountId;
+mod multiaddress;
+pub type Address = multiaddress::MultiAddress<AccountId, ()>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -94,11 +94,11 @@ pub mod opaque {
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node-template"),
 	impl_name: create_runtime_str!("node-template"),
-	authoring_version: 1,
-	spec_version: 1,
-	impl_version: 1,
+	authoring_version: 100,
+	spec_version: 100,
+	impl_version: 100,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 1,
+	transaction_version: 100,
 };
 
 pub const MILLISECS_PER_BLOCK: u64 = 6000;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 100,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 100,
+	transaction_version: 1,
 };
 
 pub const MILLISECS_PER_BLOCK: u64 = 6000;

--- a/runtime/src/multiaddress.rs
+++ b/runtime/src/multiaddress.rs
@@ -1,0 +1,90 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! MultiAddress type is a wrapper for multiple downstream account formats.
+//! Copied from `sp_runtime::multiaddress`, and can be removed and replaced when
+//! updating to a newer version of Substrate.
+
+use codec::{Encode, Decode, Codec};
+use sp_std::{vec::Vec, marker::PhantomData, fmt::Debug};
+use sp_runtime::{RuntimeDebug, traits::{LookupError, StaticLookup}};
+
+/// A multi-format address wrapper for on-chain accounts.
+#[derive(Encode, Decode, PartialEq, Eq, Clone, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Hash))]
+pub enum MultiAddress<AccountId, AccountIndex> {
+	/// It's an account ID (pubkey).
+	Id(AccountId),
+	/// It's an account index.
+	Index(#[codec(compact)] AccountIndex),
+	/// It's some arbitrary raw bytes.
+	Raw(Vec<u8>),
+	/// It's a 32 byte representation.
+	Address32([u8; 32]),
+	/// Its a 20 byte representation.
+	Address20([u8; 20]),
+}
+
+#[cfg(feature = "std")]
+impl<AccountId, AccountIndex> std::fmt::Display for MultiAddress<AccountId, AccountIndex>
+where
+	AccountId: std::fmt::Debug,
+	AccountIndex: std::fmt::Debug,
+{
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		use sp_core::hexdisplay::HexDisplay;
+		match self {
+			MultiAddress::Raw(inner) => write!(f, "MultiAddress::Raw({})", HexDisplay::from(inner)),
+			MultiAddress::Address32(inner) => write!(f, "MultiAddress::Address32({})", HexDisplay::from(inner)),
+			MultiAddress::Address20(inner) => write!(f, "MultiAddress::Address20({})", HexDisplay::from(inner)),
+			_ => write!(f, "{:?}", self),
+		}
+	}
+}
+
+impl<AccountId, AccountIndex> From<AccountId> for MultiAddress<AccountId, AccountIndex> {
+	fn from(a: AccountId) -> Self {
+		MultiAddress::Id(a)
+	}
+}
+
+impl<AccountId: Default, AccountIndex> Default for MultiAddress<AccountId, AccountIndex> {
+	fn default() -> Self {
+		MultiAddress::Id(Default::default())
+	}
+}
+
+/// A lookup implementation returning the `AccountId` from a `MultiAddress`.
+pub struct AccountIdLookup<AccountId, AccountIndex>(PhantomData<(AccountId, AccountIndex)>);
+impl<AccountId, AccountIndex> StaticLookup for AccountIdLookup<AccountId, AccountIndex>
+where
+	AccountId: Codec + Clone + PartialEq + Debug,
+	AccountIndex: Codec + Clone + PartialEq + Debug,
+	MultiAddress<AccountId, AccountIndex>: Codec,
+{
+	type Source = MultiAddress<AccountId, AccountIndex>;
+	type Target = AccountId;
+	fn lookup(x: Self::Source) -> Result<Self::Target, LookupError> {
+		match x {
+			MultiAddress::Id(i) => Ok(i),
+			_ => Err(LookupError),
+		}
+	}
+	fn unlookup(x: Self::Target) -> Self::Source {
+		MultiAddress::Id(x)
+	}
+}


### PR DESCRIPTION
This PR is a quality of life improvement for developers and Jaco who manages custom types.

With this PR, we are patching in the Multiaddress update from Substrate master that was not included in v2.0.1.

This will make it so that the Polkadot JS Apps can by default use the Multiaddress format, which is what we will be using across Polkadot, Kusama, and many other parachain teams which have already switched.

When the node template is updated again to the latest master, this file can simply be deleted and directly replaced with what is in `sp_runtime::multiadress`.

cc @jacogr