### PR TITLE
Include Playground link in Node Template README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Substrate Node Template
 
+[![Try on playground](https://img.shields.io/badge/Playground-Node_Template-brightgreen?logo=Parity%20Substrate)](https://playground.substrate.dev/?deploy=node-template)
+
 A fresh FRAME-based [Substrate](https://www.substrate.io/) node, ready for hacking :rocket:
 
 ## Getting Started
 
-Follow these steps to get started with the Node Template :hammer_and_wrench:
+Follow the steps below to get started with the Node Template, or get it up and running right from your browser 
+in just a few clicks using [Playground](https://playground.substrate.dev/) :hammer_and_wrench:
 
 ### Rust Setup
 


### PR DESCRIPTION
Addresses [#977](https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/977).

This adds a way for new developers to get started with Playground if they prefer.