### PR TITLE
fix missing docker-compose volume source (./.local)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and play experience for setting up the development environment. To get all the c
 
 ### Rust Setup
 
-First, complete the [basic Rust setup instructions](./doc/rust-setup.md).
+First, complete the [basic Rust setup instructions](./docs/rust-setup.md).
 
 ### Run
 

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -6,5 +6,7 @@ echo "*** Start Substrate node template ***"
 
 cd $(dirname ${BASH_SOURCE[0]})/..
 
+mkdir -p ./.local
+
 docker-compose down --remove-orphans
 docker-compose run --rm --service-ports dev $@


### PR DESCRIPTION
The docker-compose.yml file binds a volume from ./.local path but if the path does not exist it fails (e.g. a fresh clone from this repo will fail to run docker). Changes are made to make docker_run.sh to make the directory if it does not exist.
