### PR TITLE
Remove AccountIndex from runtime

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,10 +52,6 @@ pub type Signature = MultiSignature;
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
-/// The type for looking up accounts. We don't expect more than 4 billion of them, but you
-/// never know...
-pub type AccountIndex = u32;
-
 /// Balance of an account.
 pub type Balance = u128;
 


### PR DESCRIPTION
This commit removes the `AccountIndex` from the runtime/src/lib.rs as the `AccountIndex` type is typically used to configure the Indices pallet (https://substrate.dev/rustdocs/v3.0.0/pallet_indices/trait.Config.html) which is not used by the node template, so there is no point to include it.