### PR TITLE
Minor Nix environent tweaks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,7 @@
-use_nix
-eval "$(lorri direnv)"
+# If lorri exists, better try it first.
+if has lorri; then
+    eval "$(lorri direnv)"
+else
+    # Otherwise fall back to pure nix
+    use nix
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,6 @@ let
     });
   pinned = builtins.fetchGit {
     # Descriptive name to make the store path easier to identify
-    name = "nixos-unstable-2020-04-26";
     url = "https://github.com/nixos/nixpkgs/";
     # Commit hash for nixos-unstable as of 2020-04-26
     # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
@@ -14,20 +13,23 @@ let
     rev = "1fe6ed37fd9beb92afe90671c0c2a662a03463dd";
   };
   nixpkgs = import pinned { overlays = [ mozillaOverlay ]; };
-  rust-nightly = with nixpkgs; ((rustChannelOf { date = "2021-03-01"; channel = "nightly"; }).rust.override {
+  toolchain = with nixpkgs; (rustChannelOf { date = "2021-03-01"; channel = "nightly"; });
+  rust-wasm = toolchain.rust.override {
     targets = [ "wasm32-unknown-unknown" ];
-  });
+  };
 in
 with nixpkgs; pkgs.mkShell {
   buildInputs = [
     clang
     pkg-config
-    rust-nightly
+    rust-wasm
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
   PROTOC = "${protobuf}/bin/protoc";
+  RUST_SRC_PATH = "${toolchain.rust-src}/lib/rustlib/src/rust/library/";
   ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+
 }


### PR DESCRIPTION
- envrc: made lorri optional
- shell.nix: added RUST_SRC_PATH, so rust-analyzer works out of the box

Lorri is not ubiquitous to every Nix user, so I made it optional. Also,
it's direnv command provides all the env you need, so `use_nix` was breaking
the point of using lorri as a background builder.

RUST_SRC_PATH is self-explanatory, and is needed for rust-analyzer to provide
code completion.
