### PR TITLE
fix: add edition 2021 to manifest #296

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["edition2021"]
 [package]
 name = "node-template"
 version = "4.0.0-dev"

--- a/pallets/template/Cargo.toml
+++ b/pallets/template/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["edition2021"]
 [package]
 name = "pallet-template"
 version = "4.0.0-dev"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["edition2021"]
 [package]
 name = "node-template-runtime"
 version = "4.0.0-dev"


### PR DESCRIPTION
The fix proposed for #296 did not work for me, but this one does. 