### PR TITLE
Improvements to Kitties tests

### DIFF
--- a/pallets/kitties/src/lib.rs
+++ b/pallets/kitties/src/lib.rs
@@ -367,16 +367,17 @@ pub mod pallet {
 
 			// Mutating state here via a balance transfer, so nothing is allowed to fail after this.
 			if let Some(bid_price) = maybe_bid_price {
+				// Current kitty price 
 				if let Some(price) = kitty.price {
 					ensure!(bid_price >= price, Error::<T>::BidPriceTooLow);
 					// Transfer the amount from buyer to seller
-					T::Currency::transfer(&to, &from, price, ExistenceRequirement::KeepAlive)?;
+					T::Currency::transfer(&to, &from, bid_price, ExistenceRequirement::KeepAlive)?;
 					// Deposit sold event
 					Self::deposit_event(Event::Sold {
 						seller: from.clone(),
 						buyer: to.clone(),
 						kitty: kitty_id,
-						price,
+						price: bid_price,
 					});
 				} else {
 					return Err(Error::<T>::NotForSale.into())

--- a/pallets/kitties/src/lib.rs
+++ b/pallets/kitties/src/lib.rs
@@ -265,7 +265,7 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		// Generates and returns DNA and Gender
-		fn gen_dna() -> ([u8; 16], Gender) {
+		pub fn gen_dna() -> ([u8; 16], Gender) {
 			// Create randomness
 			let random = T::KittyRandomness::random(&b"dna"[..]).0;
 
@@ -283,31 +283,41 @@ pub mod pallet {
 
 			// Generate Gender
 			if hash[0] % 2 == 0 {
+				// Males are identified by having a even leading byte
 				(hash, Gender::Male)
 			} else {
+            	// Females are identified by having a odd leading byte
 				(hash, Gender::Female)
 			}
 		}
 
 		// Picks from existing DNA
 		fn mutate_dna_fragment(dna_fragment1: u8, dna_fragment2: u8, random_value: u8) -> u8 {
+			// Given some random u8 
 			if random_value % 2 == 0 {
+				// either return `dna_fragment1` if its an even value 
 				dna_fragment1
 			} else {
+				// or return `dna_fragment2` if its an odd value
 				dna_fragment2
 			}
 		}
 
 		// Generates a new kitty using existing kitties
 		pub fn breed_dna(parent1: &[u8; 16], parent2: &[u8; 16]) -> ([u8; 16], Gender) {
+			
+			// Call `gen_dna` to generate random kitty DNA 
+			// We don't know what Gender this kitty is yet
 			let (mut new_dna, new_gender) = Self::gen_dna();
 
+			// randomly combine DNA using `mutate_dna_fragment`
 			for i in 0..new_dna.len() {
 				// At this point, `new_dna` is a randomly generated set of bytes, so we can
-				// extract each of its bytes to act as a random value.
+				// extract each of its bytes to act as a random value for `mutate_dna_fragment`
 				new_dna[i] = Self::mutate_dna_fragment(parent1[i], parent2[i], new_dna[i])
 			}
-			(new_dna, new_gender)
+			// return new DNA and gender
+			(new_dna, new_gender)	
 		}
 
 		// Helper to mint a kitty

--- a/pallets/kitties/src/tests.rs
+++ b/pallets/kitties/src/tests.rs
@@ -174,10 +174,7 @@ fn breed_kitty_works() {
 		// Breeder can only breed kitties they own
 		assert_ok!(SubstrateKitties::breed_kitty(Origin::signed(1), mom, dad));
 
-		// Check that newly bred kitty exists
-		assert_ok!(KittiesOwned::<Test>::get(1)[3]);
-
-		// Check the new DNA is from the mom and dad
+		// Check the new kitty exists and DNA is from the mom and dad
 		let new_dna = KittiesOwned::<Test>::get(1)[3];
 		for &i in new_dna.iter() {
 			assert!(i == 0u8 || i == 1u8)
@@ -409,16 +406,15 @@ fn high_bid_transfers_correctly() {
 		let set_price = 4;
 		assert_ok!(SubstrateKitties::set_price(Origin::signed(2), id, Some(set_price)));
 
-		// Account #1 buys kitty at 10x the price
-		assert_ok!(SubstrateKitties::buy_kitty(Origin::signed(1), id, set_price * 10));
+		// Account #1 buys kitty at 2x the price
+		assert_ok!(SubstrateKitties::buy_kitty(Origin::signed(1), id, set_price*2));
 
 		// Balance transfer worked as expected
 		let balance_1_after = Balances::free_balance(&1);
 		let balance_2_after = Balances::free_balance(&2);
 
-		assert!(balance_1_before - set_price * 10  == balance_1_after);
-		assert!(balance_2_before + set_price * 10 == balance_2_after);
-
+		assert!(balance_1_before - set_price*2  == balance_1_after);
+		assert!(balance_2_before + set_price*2 == balance_2_after);
 
 		// Check that it's not possible to buy a kitty if max is reached
 		// Set max kitties for account #10

--- a/pallets/kitties/src/tests.rs
+++ b/pallets/kitties/src/tests.rs
@@ -364,18 +364,34 @@ fn buy_kitty_works() {
 			SubstrateKitties::buy_kitty(Origin::signed(10), id, 2),
 			Error::<Test>::NotForSale
 		);
+
+		// Check buy_kitty fails when balance is too low
+		let price = u64::MAX;
+		assert_ok!(SubstrateKitties::set_price(Origin::signed(2), id, Some(price)));
+
+		assert_noop!(
+			SubstrateKitties::buy_kitty(Origin::signed(1), id, price),
+			pallet_balances::Error::<Test>::InsufficientBalance
+		);
 	});
 }
 
 #[test]
-fn price_too_low() {
+fn buy_kitty_fails() {
 	new_test_ext(vec![
 		(1, *b"1234567890123456", Gender::Female),
 		(2, *b"123456789012345a", Gender::Male),
 	])
 	.execute_with(|| {
+		// Check buy_kitty fails when kitty is not for sale
+		let id = KittiesOwned::<Test>::get(1)[0];
+		// Kitty is not for sale
+		assert_noop!(
+			SubstrateKitties::buy_kitty(Origin::signed(2), id, 2),
+			Error::<Test>::NotForSale
+		);
+		
 		// Check buy_kitty fails when bid price is too low
-
 		// New price is set to 4
 		let id = KittiesOwned::<Test>::get(2)[0];
 		let set_price = 4;
@@ -426,44 +442,6 @@ fn high_bid_transfers_correctly() {
 		assert_noop!(
 			SubstrateKitties::buy_kitty(Origin::signed(10), id, set_price * 10),
 			Error::<Test>::TooManyOwned
-		);
-	});
-}
-
-#[test]
-fn too_low_balance_should_fail() {
-	new_test_ext(vec![
-		(1, *b"1234567890123456", Gender::Female),
-		(2, *b"123456789012345a", Gender::Male),
-	])
-	.execute_with(|| {
-		// Check buy_kitty fails when balance is too low
-
-		// Use some kitty in storage owned by account 2 and set a high price
-		let id = KittiesOwned::<Test>::get(2)[0];
-		let price = u64::MAX;
-		assert_ok!(SubstrateKitties::set_price(Origin::signed(2), id, Some(price)));
-
-		assert_noop!(
-			SubstrateKitties::buy_kitty(Origin::signed(1), id, price),
-			pallet_balances::Error::<Test>::InsufficientBalance
-		);
-	});
-}
-
-#[test]
-fn kitty_not_for_sale() {
-	new_test_ext(vec![
-		(1, *b"1234567890123456", Gender::Female),
-		(2, *b"123456789012345a", Gender::Male),
-	])
-	.execute_with(|| {
-		// Check buy_kitty fails when kitty is not for sale
-		let id = KittiesOwned::<Test>::get(1)[0];
-		// Kitty is not for sale
-		assert_noop!(
-			SubstrateKitties::buy_kitty(Origin::signed(2), id, 2),
-			Error::<Test>::NotForSale
 		);
 	});
 }


### PR DESCRIPTION
Improvements include:
- Comments to add clarity to code
- Adding testing logic for transferring balances 
- Fixed a bug in the pallet caught by `transfer_kitty_should_work`: bid price never got debited correctly so seller would just get their original price from sale, and not the actual bid price.
- Refactored a whole bunch, trying to keep to the "works / fails" pattern for each dispatchable (down from 21 tests to 11).