### PR TITLE
improve(node): update clone client to avoid borrowed

### DIFF
--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -46,7 +46,7 @@ where
 	let FullDeps { client, pool, deny_unsafe } = deps;
 
 	module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
-	module.merge(TransactionPayment::new(client).into_rpc())?;
+	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed


### PR DESCRIPTION
In this description of [Substrate tutorials](https://docs.substrate.io/tutorials/work-with-pallets/contracts-pallet/#expose-the-contracts-api)

```rust
module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
module.merge(Contracts::new(client.clone()).into_rpc())?; // Add this line
```

However, `client` does not actually have clone, and there will got `value borrowed here after move` error when compiling.

https://github.com/substrate-developer-hub/substrate-node-template/blob/6a8b2b12371395979099d2c79ccc1860531b0449/node/src/rpc.rs#L49

So, I want to add `client.clone()` to avoid this error :)
