### PR TITLE
Update to latest enum syntax

### DIFF
--- a/pallets/template/src/lib.rs
+++ b/pallets/template/src/lib.rs
@@ -45,7 +45,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// Event documentation should end with an array that provides descriptive names for event
 		/// parameters. [something, who]
-		SomethingStored(u32, T::AccountId),
+		SomethingStored { something: u32, who: T::AccountId },
 	}
 
 	// Errors inform users that something went wrong.
@@ -75,7 +75,7 @@ pub mod pallet {
 			<Something<T>>::put(something);
 
 			// Emit an event.
-			Self::deposit_event(Event::SomethingStored(something, who));
+			Self::deposit_event(Event::SomethingStored { something, who });
 			// Return a successful DispatchResultWithPostInfo
 			Ok(())
 		}


### PR DESCRIPTION
Updates `SomethingStored(u32, T::AccountId),` to `SomethingStored { something: u32, who: T::AccountId },` to follow latest FRAME syntax.