### PR TITLE
Add Medical record pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-storage",
 ]
 
@@ -1738,7 +1738,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-tracing",
 ]
 
@@ -1780,7 +1780,7 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-tracing",
  "sp-weights",
  "tt-call",
@@ -1835,7 +1835,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-version",
  "sp-weights",
 ]
@@ -1852,7 +1852,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -1873,7 +1873,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -3732,7 +3732,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -3893,7 +3893,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -3908,7 +3908,7 @@ dependencies = [
  "scale-info",
  "sp-authorship",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -3923,7 +3923,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -3946,7 +3946,22 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
+]
+
+[[package]]
+name = "pallet-medical-record"
+version = "4.0.0-dev"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.29)",
 ]
 
 [[package]]
@@ -3960,7 +3975,7 @@ dependencies = [
  "safe-mix",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -3980,7 +3995,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-trie",
 ]
 
@@ -3995,7 +4010,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -4026,7 +4041,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-timestamp",
 ]
 
@@ -4043,7 +4058,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -5920,7 +5935,7 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6457,7 +6472,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-trie",
  "sp-version",
  "thiserror",
@@ -6485,7 +6500,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6499,7 +6514,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-debug-derive",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "static_assertions",
 ]
 
@@ -6512,7 +6527,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6524,7 +6539,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6559,7 +6574,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-version",
  "thiserror",
 ]
@@ -6578,7 +6593,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-timestamp",
 ]
 
@@ -6592,7 +6607,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-timestamp",
 ]
 
@@ -6632,7 +6647,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-storage",
  "ss58-registry",
  "substrate-bip39",
@@ -6652,7 +6667,7 @@ dependencies = [
  "digest 0.10.5",
  "sha2 0.10.6",
  "sha3",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "twox-hash",
 ]
 
@@ -6693,7 +6708,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-storage",
 ]
 
@@ -6712,7 +6727,7 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6725,7 +6740,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "thiserror",
 ]
 
@@ -6747,7 +6762,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime-interface",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
@@ -6841,7 +6856,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-weights",
 ]
 
@@ -6856,7 +6871,7 @@ dependencies = [
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
@@ -6884,7 +6899,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-wasm-interface",
  "wasmi",
 ]
@@ -6900,7 +6915,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-staking",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6911,7 +6926,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6929,12 +6944,17 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-trie",
  "thiserror",
  "tracing",
  "trie-root",
 ]
+
+[[package]]
+name = "sp-std"
+version = "4.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.29#b97f87e33bd8cbc6548d3806a46e4743268c341c"
 
 [[package]]
 name = "sp-std"
@@ -6951,7 +6971,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "sp-debug-derive",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6964,7 +6984,7 @@ dependencies = [
  "sp-externalities",
  "sp-io",
  "sp-runtime-interface",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]
@@ -6979,7 +6999,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "thiserror",
 ]
 
@@ -6989,7 +7009,7 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32#5ea6d95309aaccfa399c5f72e5a14a4b7c6c4ca1"
 dependencies = [
  "parity-scale-codec",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -7016,7 +7036,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-trie",
 ]
 
@@ -7036,7 +7056,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "scale-info",
  "sp-core",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "thiserror",
  "tracing",
  "trie-db",
@@ -7055,7 +7075,7 @@ dependencies = [
  "serde",
  "sp-core-hashing-proc-macro",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -7079,7 +7099,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
  "wasmi",
  "wasmtime",
 ]
@@ -7097,7 +7117,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-debug-derive",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.32)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "node",
     "pallets/template",
+    "pallets/medical-record",
     "runtime",
 ]
 [profile.release]

--- a/pallets/medical-record/Cargo.toml
+++ b/pallets/medical-record/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "pallet-medical-record"
+version = "4.0.0-dev"
+description = "FRAME pallet template for defining custom runtime logic."
+authors = ["Substrate DevHub <https://github.com/substrate-developer-hub>"]
+homepage = "https://substrate.io"
+edition = "2021"
+license = "Unlicense"
+publish = false
+repository = "https://github.com/substrate-developer-hub/substrate-node-template/"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+	"derive",
+] }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.29", default-features = false }
+
+[dev-dependencies]
+sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-benchmarking?/std",
+	"frame-support/std",
+	"frame-system/std",
+	"scale-info/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/medical-record/README.md
+++ b/pallets/medical-record/README.md
@@ -1,0 +1,1 @@
+License: Unlicense

--- a/pallets/medical-record/src/benchmarking.rs
+++ b/pallets/medical-record/src/benchmarking.rs
@@ -1,0 +1,20 @@
+//! Benchmarking setup for pallet-template
+
+use super::*;
+
+#[allow(unused)]
+use crate::Pallet as Template;
+use frame_benchmarking::{benchmarks, whitelisted_caller};
+use frame_system::RawOrigin;
+
+benchmarks! {
+	do_something {
+		let s in 0 .. 100;
+		let caller: T::AccountId = whitelisted_caller();
+	}: _(RawOrigin::Signed(caller), s)
+	verify {
+		assert_eq!(Something::<T>::get(), Some(s));
+	}
+
+	impl_benchmark_test_suite!(Template, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/pallets/medical-record/src/lib.rs
+++ b/pallets/medical-record/src/lib.rs
@@ -1,0 +1,94 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use scale_info::TypeInfo;
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type MaxRecordContentLength: Get<u32>;
+		type SignatureLength: Get<u32>;
+		type MaxRecordLength: Get<u32>;
+	}
+
+	type RecordId = u32;
+	type RecordContent<T> = BoundedVec<u8, <T as Config>::MaxRecordContentLength>;
+	type Signature<T> = BoundedVec<u8, <T as Config>::SignatureLength>;
+
+	#[derive(Decode, Encode, MaxEncodedLen, TypeInfo)]
+	#[scale_info(skip_type_params(T))]
+	pub enum Record<T: Config> {
+		VerifiedRecord(RecordId, T::AccountId, RecordContent<T>, Signature<T>),
+		UnverifiedRecord(RecordId, T::AccountId, RecordContent<T>),
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn patient_records)]
+	pub type PatientRecords<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AccountId, BoundedVec<Record<T>, T::MaxRecordLength>>;
+
+	// Pallets use events to inform users when important changes are made.
+	// https://docs.substrate.io/main-docs/build/events-errors/
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		PatientAccountCreated(T::AccountId),
+		DoctorAccountCreated(T::AccountId),
+		PatientRecordsUpdated(u32, T::AccountId),
+		DoctorRecordsUpdated(u32, T::AccountId),
+		PatientRecordVerified(u32),
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		AccountNotFound,
+		AccountAlreadyExist,
+		InvalidRecordId,
+		/// Error names should be descriptive.
+		NoneValue,
+		/// Errors should have helpful documentation associated with them.
+		StorageOverflow,
+	}
+
+	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
+	// These functions materialize as "extrinsics", which are often compared to transactions.
+	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(10_000)]
+		pub fn create_patient_account(origin: OriginFor<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			match Self::patient_records(&who) {
+				Some(_) => Err(Error::<T>::AccountAlreadyExist.into()),
+				None => {
+					<PatientRecords<T>>::insert(
+						who.clone(),
+						BoundedVec::with_bounded_capacity(T::MaxRecordLength::get() as usize),
+					);
+					Self::deposit_event(Event::PatientAccountCreated(who));
+					Ok(())
+				},
+			}
+		}
+	}
+}

--- a/pallets/medical-record/src/mock.rs
+++ b/pallets/medical-record/src/mock.rs
@@ -10,6 +10,10 @@ use sp_runtime::{
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
+type MockMaxRecordContentLength = ConstU32<1>;
+type MockSignatureLength = ConstU32<1>;
+pub type MockMaxRecordLength = ConstU32<3>;
+
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
 	pub enum Test where
@@ -51,9 +55,9 @@ impl system::Config for Test {
 
 impl pallet_medical_record::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type MaxRecordContentLength = ConstU32<1>;
-	type SignatureLength = ConstU32<1>;
-	type MaxRecordLength = ConstU32<3>;
+	type MaxRecordContentLength = MockMaxRecordContentLength;
+	type SignatureLength = MockSignatureLength;
+	type MaxRecordLength = MockMaxRecordLength;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/medical-record/src/mock.rs
+++ b/pallets/medical-record/src/mock.rs
@@ -51,9 +51,9 @@ impl system::Config for Test {
 
 impl pallet_medical_record::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type MaxRecordContentLength = ConstU32<10>;
-	type SignatureLength = ConstU32<4>;
-	type MaxRecordLength = ConstU32<10>;
+	type MaxRecordContentLength = ConstU32<1>;
+	type SignatureLength = ConstU32<1>;
+	type MaxRecordLength = ConstU32<1>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/medical-record/src/mock.rs
+++ b/pallets/medical-record/src/mock.rs
@@ -53,7 +53,7 @@ impl pallet_medical_record::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type MaxRecordContentLength = ConstU32<1>;
 	type SignatureLength = ConstU32<1>;
-	type MaxRecordLength = ConstU32<1>;
+	type MaxRecordLength = ConstU32<3>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/medical-record/src/mock.rs
+++ b/pallets/medical-record/src/mock.rs
@@ -1,0 +1,62 @@
+use crate as pallet_medical_record;
+use frame_support::traits::{ConstU16, ConstU64};
+use frame_system as system;
+use sp_core::{ConstU32, H256};
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system,
+		MedicalRecord: pallet_medical_record,
+	}
+);
+
+impl system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+impl pallet_medical_record::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type MaxRecordContentLength = ConstU32<10>;
+	type SignatureLength = ConstU32<4>;
+	type MaxRecordLength = ConstU32<10>;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+}

--- a/pallets/medical-record/src/tests.rs
+++ b/pallets/medical-record/src/tests.rs
@@ -1,21 +1,18 @@
 use crate::{mock::*, Error, UserType};
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, BoundedVec};
 use frame_system::RawOrigin;
 
 #[test]
 fn user_can_create_account() {
 	new_test_ext().execute_with(|| {
 		let o = RuntimeOrigin::signed(1);
-
 		assert_ok!(MedicalRecord::create_account(o.clone(), UserType::Patient));
-		let ro: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
 
+		let ro: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
 		match ro.ok().unwrap() {
 			RawOrigin::Signed(account_id) => {
-				let account_created = match MedicalRecord::records(account_id, UserType::Patient) {
-					None => false,
-					Some(_) => true,
-				};
+				let account_created =
+					MedicalRecord::records(account_id, UserType::Patient).is_some();
 				assert!(account_created, "failed to create an account");
 			},
 			_ => (),
@@ -24,6 +21,41 @@ fn user_can_create_account() {
 		assert_noop!(
 			MedicalRecord::create_account(o, UserType::Patient),
 			Error::<Test>::AccountAlreadyExist
+		);
+	});
+}
+
+#[test]
+fn patient_can_add_record() {
+	new_test_ext().execute_with(|| {
+		let o = RuntimeOrigin::signed(1);
+		assert_ok!(MedicalRecord::create_account(o.clone(), UserType::Patient));
+		assert_ok!(MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()));
+
+		let ro: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
+		match ro.ok().unwrap() {
+			RawOrigin::Signed(account_id) => {
+				match MedicalRecord::records(account_id, UserType::Patient) {
+					Some(a) => {
+						assert_eq!(a.len(), 1);
+					},
+					None => (),
+				}
+			},
+			_ => (),
+		}
+
+		assert_noop!(
+			MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()),
+			Error::<Test>::ExceedsMaxRecordLength
+		);
+
+		assert_noop!(
+			MedicalRecord::patient_adds_record(
+				RuntimeOrigin::signed(2),
+				BoundedVec::with_max_capacity()
+			),
+			Error::<Test>::AccountNotFound
 		);
 	});
 }

--- a/pallets/medical-record/src/tests.rs
+++ b/pallets/medical-record/src/tests.rs
@@ -1,17 +1,18 @@
-use crate::{mock::*, Error};
+use crate::{mock::*, Error, UserType};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 
 #[test]
-fn patient_can_create_account() {
+fn user_can_create_account() {
 	new_test_ext().execute_with(|| {
 		let o = RuntimeOrigin::signed(1);
 
-		assert_ok!(MedicalRecord::create_patient_account(o.clone()));
-		let mb_raw_origin: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
-		match mb_raw_origin.ok().unwrap() {
+		assert_ok!(MedicalRecord::create_account(o.clone(), UserType::Patient));
+		let ro: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
+
+		match ro.ok().unwrap() {
 			RawOrigin::Signed(account_id) => {
-				let account_created = match MedicalRecord::patient_records(account_id) {
+				let account_created = match MedicalRecord::records(account_id, UserType::Patient) {
 					None => false,
 					Some(_) => true,
 				};
@@ -20,6 +21,9 @@ fn patient_can_create_account() {
 			_ => (),
 		}
 
-		assert_noop!(MedicalRecord::create_patient_account(o), Error::<Test>::AccountAlreadyExist);
+		assert_noop!(
+			MedicalRecord::create_account(o, UserType::Patient),
+			Error::<Test>::AccountAlreadyExist
+		);
 	});
 }

--- a/pallets/medical-record/src/tests.rs
+++ b/pallets/medical-record/src/tests.rs
@@ -1,0 +1,25 @@
+use crate::{mock::*, Error};
+use frame_support::{assert_noop, assert_ok};
+use frame_system::RawOrigin;
+
+#[test]
+fn patient_can_create_account() {
+	new_test_ext().execute_with(|| {
+		let o = RuntimeOrigin::signed(1);
+
+		assert_ok!(MedicalRecord::create_patient_account(o.clone()));
+		let mb_raw_origin: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
+		match mb_raw_origin.ok().unwrap() {
+			RawOrigin::Signed(account_id) => {
+				let account_created = match MedicalRecord::patient_records(account_id) {
+					None => false,
+					Some(_) => true,
+				};
+				assert!(account_created, "failed to create an account");
+			},
+			_ => (),
+		}
+
+		assert_noop!(MedicalRecord::create_patient_account(o), Error::<Test>::AccountAlreadyExist);
+	});
+}

--- a/pallets/medical-record/src/tests.rs
+++ b/pallets/medical-record/src/tests.rs
@@ -1,6 +1,7 @@
-use crate::{mock::*, Error, UserType};
+use crate::{mock::*, Error, Record, UserType};
 use frame_support::{assert_noop, assert_ok, BoundedVec};
 use frame_system::RawOrigin;
+use sp_core::Get;
 
 #[test]
 fn user_can_create_account() {
@@ -24,13 +25,28 @@ fn patient_can_add_record() {
 	new_test_ext().execute_with(|| {
 		let o = RuntimeOrigin::signed(1);
 		assert_ok!(MedicalRecord::create_account(o.clone(), UserType::Patient));
-		assert_ok!(MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()));
-		assert_ok!(MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()));
-		assert_ok!(MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()));
+		let max_record_len = <MockMaxRecordLength as Get<u32>>::get() as usize;
+		for _ in 0..max_record_len {
+			assert_ok!(MedicalRecord::patient_adds_record(
+				o.clone(),
+				BoundedVec::with_max_capacity()
+			));
+		}
 
 		let records =
 			MedicalRecord::records(origin_to_account_id(o.clone()), UserType::Patient).unwrap();
 		assert_eq!(records.len(), 3);
+		assert_eq!(
+			records
+				.into_iter()
+				.filter(|r| match r {
+					Record::UnverifiedRecord(_, _, _) => true,
+					_ => false,
+				})
+				.collect::<Vec<_>>()
+				.len(),
+			max_record_len as usize
+		);
 
 		assert_noop!(
 			MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()),

--- a/pallets/medical-record/src/tests.rs
+++ b/pallets/medical-record/src/tests.rs
@@ -8,15 +8,9 @@ fn user_can_create_account() {
 		let o = RuntimeOrigin::signed(1);
 		assert_ok!(MedicalRecord::create_account(o.clone(), UserType::Patient));
 
-		let ro: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
-		match ro.ok().unwrap() {
-			RawOrigin::Signed(account_id) => {
-				let account_created =
-					MedicalRecord::records(account_id, UserType::Patient).is_some();
-				assert!(account_created, "failed to create an account");
-			},
-			_ => (),
-		}
+		let account_created =
+			MedicalRecord::records(origin_to_account_id(o.clone()), UserType::Patient).is_some();
+		assert!(account_created, "failed to create an account");
 
 		assert_noop!(
 			MedicalRecord::create_account(o, UserType::Patient),
@@ -31,19 +25,12 @@ fn patient_can_add_record() {
 		let o = RuntimeOrigin::signed(1);
 		assert_ok!(MedicalRecord::create_account(o.clone(), UserType::Patient));
 		assert_ok!(MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()));
+		assert_ok!(MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()));
+		assert_ok!(MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()));
 
-		let ro: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
-		match ro.ok().unwrap() {
-			RawOrigin::Signed(account_id) => {
-				match MedicalRecord::records(account_id, UserType::Patient) {
-					Some(a) => {
-						assert_eq!(a.len(), 1);
-					},
-					None => (),
-				}
-			},
-			_ => (),
-		}
+		let records =
+			MedicalRecord::records(origin_to_account_id(o.clone()), UserType::Patient).unwrap();
+		assert_eq!(records.len(), 3);
 
 		assert_noop!(
 			MedicalRecord::patient_adds_record(o.clone(), BoundedVec::with_max_capacity()),
@@ -58,4 +45,12 @@ fn patient_can_add_record() {
 			Error::<Test>::AccountNotFound
 		);
 	});
+}
+
+fn origin_to_account_id(o: RuntimeOrigin) -> u64 {
+	let ro: Result<RawOrigin<u64>, RuntimeOrigin> = o.clone().into();
+	match ro.ok().unwrap() {
+		RawOrigin::Signed(account_id) => account_id,
+		_ => unreachable!(),
+	}
 }


### PR DESCRIPTION
Add a pallet **medical-record** which provides a functionality for patient and doctor to 
* crate an account
* upload a record

Note that the records will be stored in a double map:
```
(AccountId, UserType) -> Record[]
```
The Records will be empty for Doctors for now.

Check test.rs for how to interact with the pallet.