### PR TITLE
Fix build and publish docker GitHub Action typo

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -50,4 +50,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.DOCKER_REPO }}:v${{ steps.rev.outputs.value }}, ${{ secrets.DOCKER_REPO }}:latest
+          tags: ${{ env.DOCKER_REPO }}:v${{ steps.rev.outputs.value }}, ${{ env.DOCKER_REPO }}:latest


### PR DESCRIPTION
I got an error while using this docker GitHub Action template. After checking the tag naming code I found this issue.

I believe it's a copy-paste error, and after I fix it, my GitHub Action works without any issue.