### PR TITLE
Remove and ignore .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,0 @@
-# If lorri exists, better try it first.
-if has lorri; then
-    eval "$(lorri direnv)"
-else
-    # Otherwise fall back to pure nix
-    use nix
-fi

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 # The cache for chain data in container
 .local
 
-# direnv cache
+# direnv files
+.envrc
 .direnv


### PR DESCRIPTION
If you are a direnv user but you are **not** a nix user, you cannot use direnv within this project.

If you  have direnv installed, whenever you `cd` into the `substrate-node-template` it will error with:

```
direnv: error /substrate-node-template/.envrc is blocked. Run `direnv allow` to approve its content
```

However, if you are not a nix user you cannot `direnv allow` this file as then every time you `cd` into the directory you will receive a `nix-shell: command not found` error.

This effectively prevents a developer from using direnv on this project, as their only option to prevent errors is to `direnv block` the `.envrc` file.

It does not appear that nix is required to use the `substrate-node-template` so I would suggest that the configuration of a developer's preferred shell should be local to their machine and not committed as part of the shared repository.